### PR TITLE
Allow lover version HASS then 2025

### DIFF
--- a/custom_components/mitsubishi/manifest.json
+++ b/custom_components/mitsubishi/manifest.json
@@ -9,7 +9,7 @@
   "config_flow": true,
   "iot_class": "local_polling",
   "integration_type": "device",
-  "homeassistant": "2025.1.0",
+  "homeassistant": "2024.4.3",
   "loggers": ["pymitsubishi"],
   "integration_logo": "icon.svg"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,5 @@
   "zip_release": false,
   "filename": "mitsubishi.zip",
   "country": ["AU", "NZ", "JP", "US", "CA", "GB", "EU"],
-  "homeassistant": "2025.1.0"
+  "homeassistant": "2024.4.3"
 }


### PR DESCRIPTION
I use HASS version 2024.4.3 cuz of some old integrations, and your integration works great also on that version without any additional changes to code (just lovered version in manifest.json)