### PR TITLE
Show requested state immediately, reconcile with the device

### DIFF
--- a/custom_components/mitsubishi/climate.py
+++ b/custom_components/mitsubishi/climate.py
@@ -17,7 +17,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pymitsubishi import (
     AutoMode,
@@ -30,7 +30,7 @@ from pymitsubishi import (
 
 from .const import DOMAIN
 from .coordinator import MitsubishiDataUpdateCoordinator
-from .entity import MitsubishiEntity
+from .entity import _NO_OPTIMISTIC, MitsubishiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,6 +144,8 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> float | None:
+        if (v := self._optimistic_value("target_temperature")) is not _NO_OPTIMISTIC:
+            return v
         try:
             return self.coordinator.data.general.temperature
         except AttributeError:
@@ -155,6 +157,7 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
         if temperature is None:
             return
 
+        self._set_optimistic(target_temperature=temperature)
         await self._execute_command_with_refresh(
             f"set temperature to {temperature}°C",
             self.coordinator.controller.set_temperature,
@@ -167,6 +170,8 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
         Return hvac operation i.e. heat, cool mode.
         Note that HA sees "off" as a mode; Mitsubishi has a separate PowerOnOff field, so join these
         """
+        if (v := self._optimistic_value("hvac_mode")) is not _NO_OPTIMISTIC:
+            return v
         try:
             if self.coordinator.data.general.power_on_off == PowerOnOff.OFF:
                 return HVACMode.OFF
@@ -180,12 +185,14 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
         )
 
     async def async_turn_off(self) -> None:
+        self._set_optimistic(hvac_mode=HVACMode.OFF)
         await self._execute_command_with_refresh(
             "turn off device", self.coordinator.controller.set_power, False
         )
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
+        self._set_optimistic(hvac_mode=hvac_mode)
         if hvac_mode == HVACMode.OFF:
             await self._execute_command_with_refresh(
                 f"set HVAC mode to {hvac_mode}", self.coordinator.controller.set_power, False
@@ -232,12 +239,15 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
 
     @property
     def fan_mode(self) -> str | None:
+        if (v := self._optimistic_value("fan_mode")) is not _NO_OPTIMISTIC:
+            return v
         try:
             return FAN_SPEED_MITSUBISHI_TO_HA[self.coordinator.data.general.wind_speed]
         except AttributeError:
             return None
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
+        self._set_optimistic(fan_mode=fan_mode)
         await self._execute_command_with_refresh(
             f"set fan mode to {fan_mode}",
             self.coordinator.controller.set_fan_speed,
@@ -246,12 +256,15 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
 
     @property
     def swing_mode(self) -> str | None:
+        if (v := self._optimistic_value("swing_mode")) is not _NO_OPTIMISTIC:
+            return v
         try:
             return VSWING_MITSUBISHI_TO_HA[self.coordinator.data.general.vertical_wind_direction]
         except AttributeError:
             return None
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
+        self._set_optimistic(swing_mode=swing_mode)
         await self._execute_command_with_refresh(
             f"set swing mode to {swing_mode}",
             self.coordinator.controller.set_vertical_vane,
@@ -260,12 +273,15 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
 
     @property
     def swing_horizontal_mode(self) -> str | None:
+        if (v := self._optimistic_value("swing_horizontal_mode")) is not _NO_OPTIMISTIC:
+            return v
         try:
             return HSWING_MITSUBISHI_TO_HA[self.coordinator.data.general.horizontal_wind_direction]
         except AttributeError:
             return None
 
     async def async_set_swing_horizontal_mode(self, swing_horizontal_mode: str) -> None:
+        self._set_optimistic(swing_horizontal_mode=swing_horizontal_mode)
         await self._execute_command_with_refresh(
             f"set horizontal swing mode to {swing_horizontal_mode}",
             self.coordinator.controller.set_horizontal_vane,
@@ -294,8 +310,3 @@ class MitsubishiClimate(MitsubishiEntity, ClimateEntity):
             pass
 
         return attrs
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self.async_write_ha_state()

--- a/custom_components/mitsubishi/config_flow.py
+++ b/custom_components/mitsubishi/config_flow.py
@@ -20,11 +20,13 @@ from .const import (
     CONF_ENCRYPTION_KEY,
     CONF_EXPERIMENTAL_FEATURES,
     CONF_EXTERNAL_TEMP_ENTITY,
+    CONF_OPTIMISTIC_UPDATES,
     CONF_REMOTE_TEMP_MODE,
     CONF_SCAN_INTERVAL,
     DEFAULT_ADMIN_PASSWORD,
     DEFAULT_ADMIN_USERNAME,
     DEFAULT_ENCRYPTION_KEY,
+    DEFAULT_OPTIMISTIC_UPDATES,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -64,6 +66,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): vol.All(
             vol.Coerce(int), vol.Range(min=10, max=300)
         ),
+        vol.Optional(CONF_OPTIMISTIC_UPDATES, default=DEFAULT_OPTIMISTIC_UPDATES): bool,
         vol.Optional(CONF_EXPERIMENTAL_FEATURES, default=False): bool,
     }
 )
@@ -114,6 +117,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         super().__init__()
         self._connection_data: dict[str, Any] = {}
         self._experimental_features: bool = False
+        self._optimistic_updates: bool = DEFAULT_OPTIMISTIC_UPDATES
         self._device_info: dict[str, Any] = {}
 
     @staticmethod
@@ -133,6 +137,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 # Extract experimental features flag
                 self._experimental_features = user_input.pop(CONF_EXPERIMENTAL_FEATURES, False)
+                self._optimistic_updates = user_input.pop(
+                    CONF_OPTIMISTIC_UPDATES, DEFAULT_OPTIMISTIC_UPDATES
+                )
 
                 _LOGGER.debug("Calling validate_input")
                 info = await validate_input(self.hass, user_input)
@@ -185,6 +192,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Build options
         options: dict[str, Any] = {
             CONF_EXPERIMENTAL_FEATURES: self._experimental_features,
+            CONF_OPTIMISTIC_UPDATES: self._optimistic_updates,
         }
         if self._experimental_features and external_temp_entity:
             options[CONF_EXTERNAL_TEMP_ENTITY] = external_temp_entity
@@ -205,6 +213,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self._config_entry = config_entry
         self._connection_data: dict[str, Any] = {}
         self._experimental_features: bool = False
+        self._optimistic_updates: bool = DEFAULT_OPTIMISTIC_UPDATES
 
     @property
     def config_entry(self) -> config_entries.ConfigEntry:
@@ -220,6 +229,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             try:
                 # Extract experimental features flag
                 self._experimental_features = user_input.pop(CONF_EXPERIMENTAL_FEATURES, False)
+                self._optimistic_updates = user_input.pop(
+                    CONF_OPTIMISTIC_UPDATES, DEFAULT_OPTIMISTIC_UPDATES
+                )
 
                 # Validate the connection configuration
                 _LOGGER.debug("Validating new configuration")
@@ -258,6 +270,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
         )
         current_experimental = self.config_entry.options.get(CONF_EXPERIMENTAL_FEATURES, False)
+        current_optimistic = self.config_entry.options.get(
+            CONF_OPTIMISTIC_UPDATES, DEFAULT_OPTIMISTIC_UPDATES
+        )
 
         options_schema = vol.Schema(
             {
@@ -268,6 +283,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(CONF_SCAN_INTERVAL, default=current_scan_interval): vol.All(
                     vol.Coerce(int), vol.Range(min=10, max=300)
                 ),
+                vol.Optional(CONF_OPTIMISTIC_UPDATES, default=current_optimistic): bool,
                 vol.Optional(CONF_EXPERIMENTAL_FEATURES, default=current_experimental): bool,
             }
         )
@@ -292,6 +308,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # Build new options FIRST (before any reload)
         new_options: dict[str, Any] = {
             CONF_EXPERIMENTAL_FEATURES: self._experimental_features,
+            CONF_OPTIMISTIC_UPDATES: self._optimistic_updates,
         }
         if self._experimental_features:
             # Only preserve experimental settings when experimental features are enabled

--- a/custom_components/mitsubishi/const.py
+++ b/custom_components/mitsubishi/const.py
@@ -14,6 +14,11 @@ CONF_ADMIN_PASSWORD = "admin_password"
 DEFAULT_ADMIN_PASSWORD = "me1debug@0567"
 CONF_SCAN_INTERVAL = "scan_interval"
 
+# Optimistic UI updates: show a requested value immediately and hold it until
+# the device confirms it, instead of waiting for the next refresh.
+CONF_OPTIMISTIC_UPDATES = "optimistic_updates"
+DEFAULT_OPTIMISTIC_UPDATES = False
+
 # Experimental Features
 CONF_EXPERIMENTAL_FEATURES = "experimental_features"
 

--- a/custom_components/mitsubishi/entity.py
+++ b/custom_components/mitsubishi/entity.py
@@ -11,7 +11,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_OPTIMISTIC_UPDATES, DEFAULT_OPTIMISTIC_UPDATES, DOMAIN
 from .coordinator import MitsubishiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,8 +78,15 @@ class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data is not None
 
+    @property
+    def _optimistic_enabled(self) -> bool:
+        """Whether optimistic UI updates are enabled for this config entry."""
+        return self._config_entry.options.get(CONF_OPTIMISTIC_UPDATES, DEFAULT_OPTIMISTIC_UPDATES)
+
     def _set_optimistic(self, **values: Any) -> None:
         """Show requested values immediately, until the device confirms them."""
+        if not self._optimistic_enabled:
+            return
         self._optimistic.update(values)
         for key in values:
             self._optimistic_age[key] = 0

--- a/custom_components/mitsubishi/entity.py
+++ b/custom_components/mitsubishi/entity.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -13,6 +15,15 @@ from .const import DOMAIN
 from .coordinator import MitsubishiDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# The AC is eventually consistent: a command can take longer than one refresh
+# to show up in its reported state. Keep an optimistic value until the device
+# confirms it, but give up after this many refreshes so a command that silently
+# never applies cannot pin the UI to a wrong value forever.
+OPTIMISTIC_MAX_REFRESHES = 3
+
+# Distinguishes "no optimistic override" from a legitimate override value of None.
+_NO_OPTIMISTIC = object()
 
 
 class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
@@ -30,6 +41,15 @@ class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
         super().__init__(coordinator)
         self._config_entry = config_entry
         self._key = key
+        # Values shown immediately after a command, before the device confirms
+        # them via a coordinator refresh. Keyed by property name (getattr(self,
+        # key) must return the device-derived value for that property).
+        self._optimistic: dict[str, Any] = {}
+        # Refreshes seen for each optimistic key while still unconfirmed.
+        self._optimistic_age: dict[str, int] = {}
+        # Set while reconciling so the getters return the device value, not the
+        # optimistic one, letting us compare the two.
+        self._bypass_optimistic = False
 
         if coordinator.data:
             device_mac = coordinator.data.mac
@@ -57,6 +77,47 @@ class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
     def available(self) -> bool:
         """Return if entity is available."""
         return self.coordinator.last_update_success and self.coordinator.data is not None
+
+    def _set_optimistic(self, **values: Any) -> None:
+        """Show requested values immediately, until the device confirms them."""
+        self._optimistic.update(values)
+        for key in values:
+            self._optimistic_age[key] = 0
+        self.async_write_ha_state()
+
+    def _optimistic_value(self, key: str) -> Any:
+        """Return the optimistic override for a property, or a sentinel if none.
+
+        Getters call this so a pending value takes precedence over stale device
+        data, except while reconciling (so we can read the device value itself).
+        """
+        if not self._bypass_optimistic and key in self._optimistic:
+            return self._optimistic[key]
+        return _NO_OPTIMISTIC
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        # Drop optimistic values the device now confirms; keep the rest so a
+        # slow-to-apply change doesn't briefly snap back to its old value.
+        if self._optimistic:
+            self._bypass_optimistic = True
+            try:
+                for key in list(self._optimistic):
+                    if getattr(self, key) == self._optimistic[key]:
+                        self._clear_optimistic(key)
+                    else:
+                        self._optimistic_age[key] += 1
+                        if self._optimistic_age[key] >= OPTIMISTIC_MAX_REFRESHES:
+                            self._clear_optimistic(key)
+            finally:
+                self._bypass_optimistic = False
+        self.async_write_ha_state()
+
+    def _clear_optimistic(self, key: str) -> None:
+        """Forget one optimistic override."""
+        self._optimistic.pop(key, None)
+        self._optimistic_age.pop(key, None)
 
     async def _execute_command_with_refresh(
         self, command_name: str, command_func, *args, **kwargs
@@ -107,8 +168,17 @@ class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
                 return True
             else:
                 _LOGGER.warning(f"[{self._config_entry.title}] Failed to execute {command_name}")
+                self._revert_optimistic()
                 return False
 
         except Exception as e:
             _LOGGER.error(f"[{self._config_entry.title}] Error executing {command_name}: {e}")
+            self._revert_optimistic()
             return False
+
+    def _revert_optimistic(self) -> None:
+        """Drop optimistic values after a failed command so the UI snaps back."""
+        if self._optimistic:
+            self._optimistic.clear()
+            self._optimistic_age.clear()
+            self.async_write_ha_state()

--- a/custom_components/mitsubishi/number.py
+++ b/custom_components/mitsubishi/number.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import MitsubishiDataUpdateCoordinator
-from .entity import MitsubishiEntity
+from .entity import _NO_OPTIMISTIC, MitsubishiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +54,8 @@ class MitsubishiDehumidifierNumber(MitsubishiEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the current dehumidifier level."""
+        if (v := self._optimistic_value("native_value")) is not _NO_OPTIMISTIC:
+            return v
         try:
             return self.coordinator.data.general.dehum_setting
         except AttributeError:
@@ -61,6 +63,7 @@ class MitsubishiDehumidifierNumber(MitsubishiEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the dehumidifier level."""
+        self._set_optimistic(native_value=int(value))
         await self._execute_command_with_refresh(
             f"set dehumidifier level to {value}%",
             self.coordinator.controller.set_dehumidifier,

--- a/custom_components/mitsubishi/select.py
+++ b/custom_components/mitsubishi/select.py
@@ -19,7 +19,7 @@ from .const import (
     TEMP_SOURCE_REMOTE,
 )
 from .coordinator import MitsubishiDataUpdateCoordinator
-from .entity import MitsubishiEntity
+from .entity import _NO_OPTIMISTIC, MitsubishiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +59,8 @@ class MitsubishiPowerSavingSelect(MitsubishiEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the current power saving mode."""
+        if (v := self._optimistic_value("current_option")) is not _NO_OPTIMISTIC:
+            return v
         try:
             return "Enabled" if self.coordinator.data.general.is_power_saving else "Disabled"
         except AttributeError:
@@ -67,6 +69,7 @@ class MitsubishiPowerSavingSelect(MitsubishiEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Set the power saving mode."""
         enabled = option == "Enabled"
+        self._set_optimistic(current_option=option)
         await self._execute_command_with_refresh(
             f"set power saving mode to {option}",
             self.coordinator.controller.set_power_saving,

--- a/custom_components/mitsubishi/strings.json
+++ b/custom_components/mitsubishi/strings.json
@@ -10,9 +10,11 @@
           "admin_username": "Admin Username (default: admin)",
           "admin_password": "Admin Password (default: me1debug@0567)",
           "scan_interval": "Update Interval (seconds, 10-300)",
+          "optimistic_updates": "Optimistic updates",
           "experimental_features": "Enable experimental features"
         },
         "data_description": {
+          "optimistic_updates": "Show a requested change in the UI immediately and hold it until the device confirms it, instead of waiting for the next refresh. The device is eventually consistent, so while enabled the UI may briefly show a value the device has not yet reported.",
           "experimental_features": "Enable experimental features like remote temperature sensor support. These features may change or be removed in future versions."
         }
       },
@@ -47,9 +49,11 @@
           "admin_password": "Admin Password (default: me1debug@0567)",
           "scan_interval": "Update Interval (seconds, 10-300)",
           "enable_capability_detection": "Enable capability detection",
+          "optimistic_updates": "Optimistic updates",
           "experimental_features": "Enable experimental features"
         },
         "data_description": {
+          "optimistic_updates": "Show a requested change in the UI immediately and hold it until the device confirms it, instead of waiting for the next refresh. The device is eventually consistent, so while enabled the UI may briefly show a value the device has not yet reported.",
           "experimental_features": "Enable experimental features like remote temperature sensor support. These features may change or be removed in future versions."
         }
       },

--- a/custom_components/mitsubishi/translations/en.json
+++ b/custom_components/mitsubishi/translations/en.json
@@ -10,9 +10,11 @@
           "admin_username": "Admin Username (default: admin)",
           "admin_password": "Admin Password (default: me1debug@0567)",
           "scan_interval": "Update Interval (seconds, 10-300)",
+          "optimistic_updates": "Optimistic updates",
           "experimental_features": "Enable experimental features"
         },
         "data_description": {
+          "optimistic_updates": "Show a requested change in the UI immediately and hold it until the device confirms it, instead of waiting for the next refresh. The device is eventually consistent, so while enabled the UI may briefly show a value the device has not yet reported.",
           "experimental_features": "Enable experimental features like remote temperature sensor support. These features may change or be removed in future versions."
         }
       },
@@ -47,9 +49,11 @@
           "admin_password": "Admin Password (default: me1debug@0567)",
           "scan_interval": "Update Interval (seconds, 10-300)",
           "enable_capability_detection": "Enable capability detection",
+          "optimistic_updates": "Optimistic updates",
           "experimental_features": "Enable experimental features"
         },
         "data_description": {
+          "optimistic_updates": "Show a requested change in the UI immediately and hold it until the device confirms it, instead of waiting for the next refresh. The device is eventually consistent, so while enabled the UI may briefly show a value the device has not yet reported.",
           "experimental_features": "Enable experimental features like remote temperature sensor support. These features may change or be removed in future versions."
         }
       },

--- a/custom_components/mitsubishi/translations/fr.json
+++ b/custom_components/mitsubishi/translations/fr.json
@@ -10,9 +10,11 @@
           "admin_username": "Nom d'utilisateur administrateur (par défaut : admin)",
           "admin_password": "Mot de passe administrateur (par défaut : me1debug@0567)",
           "scan_interval": "Intervalle de mise à jour (secondes, 10-300)",
+          "optimistic_updates": "Mises à jour optimistes",
           "experimental_features": "Activer les fonctionnalités expérimentales"
         },
         "data_description": {
+          "optimistic_updates": "Affiche immédiatement le changement demandé dans l'interface et le conserve jusqu'à ce que l'appareil le confirme, au lieu d'attendre la prochaine actualisation. L'appareil est à cohérence à terme, donc lorsque cette option est activée, l'interface peut brièvement afficher une valeur que l'appareil n'a pas encore signalée.",
           "experimental_features": "Active les fonctionnalités expérimentales comme la prise en charge d'un capteur de température externe. Ces fonctionnalités peuvent évoluer ou être retirées dans de futures versions."
         }
       },
@@ -47,9 +49,11 @@
           "admin_password": "Mot de passe administrateur (par défaut : me1debug@0567)",
           "scan_interval": "Intervalle de mise à jour (secondes, 10-300)",
           "enable_capability_detection": "Activer la détection des capacités",
+          "optimistic_updates": "Mises à jour optimistes",
           "experimental_features": "Activer les fonctionnalités expérimentales"
         },
         "data_description": {
+          "optimistic_updates": "Affiche immédiatement le changement demandé dans l'interface et le conserve jusqu'à ce que l'appareil le confirme, au lieu d'attendre la prochaine actualisation. L'appareil est à cohérence à terme, donc lorsque cette option est activée, l'interface peut brièvement afficher une valeur que l'appareil n'a pas encore signalée.",
           "experimental_features": "Active les fonctionnalités expérimentales comme la prise en charge d'un capteur de température externe. Ces fonctionnalités peuvent évoluer ou être retirées dans de futures versions."
         }
       },

--- a/custom_components/mitsubishi/translations/nl.json
+++ b/custom_components/mitsubishi/translations/nl.json
@@ -10,9 +10,11 @@
           "admin_username": "Admin Username (standaard: admin)",
           "admin_password": "Admin Password (standaard: me1debug@0567)",
           "scan_interval": "Update Interval (seconden, 10-300)",
+          "optimistic_updates": "Optimistische updates",
           "experimental_features": "Activeer experimental features"
         },
         "data_description": {
+          "optimistic_updates": "Toon een gevraagde wijziging onmiddellijk in de UI en behoud deze tot het toestel ze bevestigt, in plaats van te wachten op de volgende verversing. Het toestel is 'eventually consistent', dus wanneer dit actief is kan de UI kort een waarde tonen die het toestel nog niet gerapporteerd heeft.",
           "experimental_features": "Activeer experimental features zoals externe temperatuur sensor support. Deze features kunnen in de toekomst veranderen of verdwijnen in toekomstige versies."
         }
       },
@@ -47,9 +49,11 @@
           "admin_password": "Admin Password (standaard: me1debug@0567)",
           "scan_interval": "Update Interval (seconden, 10-300)",
           "enable_capability_detection": "Activeer capability detection",
+          "optimistic_updates": "Optimistische updates",
           "experimental_features": "Activeer experimentele features"
         },
         "data_description": {
+          "optimistic_updates": "Toon een gevraagde wijziging onmiddellijk in de UI en behoud deze tot het toestel ze bevestigt, in plaats van te wachten op de volgende verversing. Het toestel is 'eventually consistent', dus wanneer dit actief is kan de UI kort een waarde tonen die het toestel nog niet gerapporteerd heeft.",
           "experimental_features": "Activeer experimental features zoals externe temperatuur sensor support. Deze features kunnen in de toekomst veranderen of verdwijnen in toekomstige versies."
         }
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,31 @@ def mock_config_entry():
 
 
 @pytest.fixture
+def mock_config_entry_optimistic():
+    """Create a mock config entry with optimistic UI updates enabled."""
+    from homeassistant.const import CONF_HOST
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.mitsubishi.const import CONF_OPTIMISTIC_UPDATES, DOMAIN
+
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Test Mitsubishi AC",
+        unique_id="00:11:22:33:44:55",
+        data={
+            CONF_HOST: "192.168.1.100",
+            "encryption_key": "unregistered",
+            "admin_username": "admin",
+            "admin_password": "password",
+            "scan_interval": 30,
+            "enable_capability_detection": True,
+        },
+        options={CONF_OPTIMISTIC_UPDATES: True},
+        entry_id="test_entry_id",
+    )
+
+
+@pytest.fixture
 def mock_mitsubishi_controller():
     """Return a mock MitsubishiController instance."""
     from unittest.mock import MagicMock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,7 @@ def create_entity_with_setup():
 
         if hass:
             entity.hass = hass
+            entity.entity_id = f"{entity_class.__module__.rsplit('.', 1)[-1]}.test"
 
         return entity
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -269,6 +269,7 @@ async def test_async_set_hvac_mode_heat_from_off(hass, mock_coordinator, mock_co
     """Test setting HVAC mode to heat from off."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
     mock_coordinator.data.general.power_on_off = pymitsubishi.PowerOnOff.OFF
 
     with (
@@ -289,6 +290,7 @@ async def test_async_set_hvac_mode_heat_from_on(hass, mock_coordinator, mock_con
     """Test setting HVAC mode to heat from on."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
     mock_coordinator.data.general.power_on_off = pymitsubishi.PowerOnOff.ON
     mock_coordinator.data.general.drive_mode = pymitsubishi.DriveMode.COOLER
 
@@ -312,6 +314,7 @@ async def test_async_set_fan_mode(hass, mock_coordinator, mock_config_entry):
     mock_coordinator.data.general.power_on_off = pymitsubishi.PowerOnOff.ON
     mock_coordinator.data.general.drive_mode = pymitsubishi.DriveMode.COOLER
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -331,6 +334,7 @@ async def test_async_turn_on(hass, mock_coordinator, mock_config_entry):
     """Test turning on the climate entity."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -350,6 +354,7 @@ async def test_async_turn_off(hass, mock_coordinator, mock_config_entry):
     """Test turning off the climate entity."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -389,6 +394,7 @@ async def test_async_set_swing_mode_vertical(hass, mock_coordinator, mock_config
     """Test setting swing mode to vertical."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -409,6 +415,7 @@ async def test_async_set_horizontal_swing_mode(hass, mock_coordinator, mock_conf
     """Test setting swing mode to horizontal."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -430,6 +437,7 @@ async def test_async_set_hvac_mode_power_command_fails(hass, mock_coordinator, m
     """Test setting HVAC mode when power command fails."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass  # Set hass attribute
+    climate.entity_id = "climate.test"
     mock_coordinator.data.general.power_on_off = pymitsubishi.PowerOnOff.OFF
 
     with patch.object(climate, "_execute_command_with_refresh", new=AsyncMock()) as mock_execute:
@@ -451,6 +459,7 @@ async def test_temperature_command_validation_failure(hass, mock_coordinator, mo
     """Test temperature command when validation fails (device rejects temperature)."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass
+    climate.entity_id = "climate.test"
 
     with (
         patch.object(hass, "async_add_executor_job", new=AsyncMock()) as mock_executor,
@@ -483,6 +492,7 @@ async def test_command_execution_failure(hass, mock_coordinator, mock_config_ent
     """Test command execution when the controller command fails."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass
+    climate.entity_id = "climate.test"
 
     with patch.object(hass, "async_add_executor_job", new=AsyncMock()) as mock_executor:
         # Mock the command to return False (failure)
@@ -501,6 +511,7 @@ async def test_command_execution_exception(hass, mock_coordinator, mock_config_e
     """Test command execution when an exception occurs."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass
+    climate.entity_id = "climate.test"
 
     with patch.object(hass, "async_add_executor_job", new=AsyncMock()) as mock_executor:
         # Mock the command to raise an exception
@@ -519,6 +530,7 @@ async def test_temperature_command_validation_success(hass, mock_coordinator, mo
     """Test temperature command when validation succeeds (temperature matches expected)."""
     climate = MitsubishiClimate(mock_coordinator, mock_config_entry)
     climate.hass = hass
+    climate.entity_id = "climate.test"
 
     # Mock coordinator data to show expected temperature (validation success)
     mock_coordinator.data = {"target_temp": 25.0}  # Device accepted the temperature
@@ -541,3 +553,50 @@ async def test_temperature_command_validation_success(hass, mock_coordinator, mo
 
         mock_sleep.assert_called_once_with(0.1)
         mock_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_optimistic_kept_until_device_confirms(
+    hass, mock_coordinator, mock_config_entry, create_entity_with_setup
+):
+    """An optimistic value survives refreshes until the device reports it."""
+    climate = create_entity_with_setup(
+        MitsubishiClimate, mock_coordinator, mock_config_entry, hass=hass
+    )
+
+    climate._set_optimistic(target_temperature=22.0)
+    assert climate.target_temperature == 22.0
+
+    # Device has not applied the change yet -> optimistic value is retained.
+    mock_coordinator.data.general.temperature = 21.5
+    climate._handle_coordinator_update()
+    assert climate.target_temperature == 22.0
+    assert "target_temperature" in climate._optimistic
+
+    # Device now reports the requested value -> optimistic value is dropped.
+    mock_coordinator.data.general.temperature = 22.0
+    climate._handle_coordinator_update()
+    assert climate.target_temperature == 22.0
+    assert "target_temperature" not in climate._optimistic
+
+
+@pytest.mark.asyncio
+async def test_optimistic_gives_up_after_max_refreshes(
+    hass, mock_coordinator, mock_config_entry, create_entity_with_setup
+):
+    """A never-confirmed optimistic value is abandoned after the bound."""
+    from custom_components.mitsubishi.entity import OPTIMISTIC_MAX_REFRESHES
+
+    climate = create_entity_with_setup(
+        MitsubishiClimate, mock_coordinator, mock_config_entry, hass=hass
+    )
+
+    climate._set_optimistic(target_temperature=22.0)
+    mock_coordinator.data.general.temperature = 21.5
+
+    for _ in range(OPTIMISTIC_MAX_REFRESHES):
+        assert climate.target_temperature == 22.0
+        climate._handle_coordinator_update()
+
+    assert "target_temperature" not in climate._optimistic
+    assert climate.target_temperature == 21.5

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -557,11 +557,11 @@ async def test_temperature_command_validation_success(hass, mock_coordinator, mo
 
 @pytest.mark.asyncio
 async def test_optimistic_kept_until_device_confirms(
-    hass, mock_coordinator, mock_config_entry, create_entity_with_setup
+    hass, mock_coordinator, mock_config_entry_optimistic, create_entity_with_setup
 ):
     """An optimistic value survives refreshes until the device reports it."""
     climate = create_entity_with_setup(
-        MitsubishiClimate, mock_coordinator, mock_config_entry, hass=hass
+        MitsubishiClimate, mock_coordinator, mock_config_entry_optimistic, hass=hass
     )
 
     climate._set_optimistic(target_temperature=22.0)
@@ -582,13 +582,13 @@ async def test_optimistic_kept_until_device_confirms(
 
 @pytest.mark.asyncio
 async def test_optimistic_gives_up_after_max_refreshes(
-    hass, mock_coordinator, mock_config_entry, create_entity_with_setup
+    hass, mock_coordinator, mock_config_entry_optimistic, create_entity_with_setup
 ):
     """A never-confirmed optimistic value is abandoned after the bound."""
     from custom_components.mitsubishi.entity import OPTIMISTIC_MAX_REFRESHES
 
     climate = create_entity_with_setup(
-        MitsubishiClimate, mock_coordinator, mock_config_entry, hass=hass
+        MitsubishiClimate, mock_coordinator, mock_config_entry_optimistic, hass=hass
     )
 
     climate._set_optimistic(target_temperature=22.0)
@@ -599,4 +599,20 @@ async def test_optimistic_gives_up_after_max_refreshes(
         climate._handle_coordinator_update()
 
     assert "target_temperature" not in climate._optimistic
+    assert climate.target_temperature == 21.5
+
+
+@pytest.mark.asyncio
+async def test_optimistic_disabled_is_noop(
+    hass, mock_coordinator, mock_config_entry, create_entity_with_setup
+):
+    """With optimistic updates off (the default), the UI shows the device value only."""
+    climate = create_entity_with_setup(
+        MitsubishiClimate, mock_coordinator, mock_config_entry, hass=hass
+    )
+
+    mock_coordinator.data.general.temperature = 21.5
+    climate._set_optimistic(target_temperature=22.0)
+
+    assert climate._optimistic == {}
     assert climate.target_temperature == 21.5

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -374,7 +374,7 @@ class TestOptionsFlow:
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
         # Options are returned by async_create_entry so HA can save them to config_entry.options
-        assert result["data"] == {"experimental_features": False}
+        assert result["data"] == {"experimental_features": False, "optimistic_updates": False}
         # Connection data should be saved via async_update_entry
         expected_connection_data = {
             CONF_HOST: "192.168.1.101",
@@ -428,6 +428,7 @@ class TestOptionsFlow:
         # Options are returned by async_create_entry so HA can save them to config_entry.options
         expected_options = {
             "experimental_features": True,
+            "optimistic_updates": False,
             "external_temperature_entity": "sensor.room_temp",
         }
         assert result2["data"] == expected_options

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -58,6 +58,7 @@ async def test_async_set_native_value_success(hass, mock_coordinator, mock_confi
     """Test setting dehumidifier level successfully."""
     number = MitsubishiDehumidifierNumber(mock_coordinator, mock_config_entry)
     number.hass = hass  # Set hass attribute
+    number.entity_id = "number.test"
 
     # Mock successful controller call and asyncio.sleep
     with (
@@ -77,6 +78,7 @@ async def test_async_set_native_value_failure(hass, mock_coordinator, mock_confi
     """Test setting dehumidifier level when controller returns failure."""
     number = MitsubishiDehumidifierNumber(mock_coordinator, mock_config_entry)
     number.hass = hass  # Set hass attribute
+    number.entity_id = "number.test"
 
     # Mock failed controller call
     with (
@@ -101,6 +103,7 @@ async def test_async_set_native_value_exception(hass, mock_coordinator, mock_con
     """Test setting dehumidifier level when an exception occurs."""
     number = MitsubishiDehumidifierNumber(mock_coordinator, mock_config_entry)
     number.hass = hass  # Set hass attribute
+    number.entity_id = "number.test"
 
     # Mock exception during controller call
     with (
@@ -133,6 +136,7 @@ async def test_async_set_native_value_float_conversion(hass, mock_coordinator, m
     """Test that float values are properly converted to integers for the controller."""
     number = MitsubishiDehumidifierNumber(mock_coordinator, mock_config_entry)
     number.hass = hass  # Set hass attribute
+    number.entity_id = "number.test"
 
     # Test that 85.7 gets converted to 85 (int)
     with (

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -60,6 +60,7 @@ async def test_power_saving_select_async_select_option_enabled(
     """Test power saving select option selection to enabled."""
     select = MitsubishiPowerSavingSelect(mock_coordinator, mock_config_entry)
     select.hass = hass  # Set hass attribute
+    select.entity_id = "select.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -80,6 +81,7 @@ async def test_power_saving_select_async_select_option_disabled(
     """Test power saving select option selection to disabled."""
     select = MitsubishiPowerSavingSelect(mock_coordinator, mock_config_entry)
     select.hass = hass  # Set hass attribute
+    select.entity_id = "select.test"
 
     with (
         patch.object(mock_coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh,
@@ -187,6 +189,7 @@ async def test_temperature_source_select_switch_to_internal(
     mock_coordinator.set_remote_temp_mode = AsyncMock()
     select = MitsubishiTemperatureSourceSelect(mock_coordinator, mock_config_entry_experimental)
     select.hass = hass
+    select.entity_id = "select.test"
     select.async_write_ha_state = MagicMock()
 
     await select.async_select_option("Internal")
@@ -204,6 +207,7 @@ async def test_temperature_source_select_switch_to_remote_no_entity(
     mock_coordinator.set_remote_temp_mode = AsyncMock()
     select = MitsubishiTemperatureSourceSelect(mock_coordinator, mock_config_entry)
     select.hass = hass
+    select.entity_id = "select.test"
     select.async_write_ha_state = MagicMock()
 
     await select.async_select_option("Remote")
@@ -219,6 +223,7 @@ async def test_temperature_source_select_extra_state_attributes_no_entity(
     """Test temperature source select extra state attributes without external entity."""
     select = MitsubishiTemperatureSourceSelect(mock_coordinator, mock_config_entry)
     select.hass = hass
+    select.entity_id = "select.test"
 
     attributes = select.extra_state_attributes
     assert attributes == {"source": "Mitsubishi AC"}


### PR DESCRIPTION
The AC returns its old state right after a command, so changes took a few seconds to show up in the UI.

Show the requested value immediately and hold it until the device confirms it (or a few refreshes pass, as a safety bound), reverting if the command fails. Covers climate, select and number entities.