### PR TITLE
Report air conditioner connection errors as UpdateFailed

### DIFF
--- a/custom_components/mitsubishi/coordinator.py
+++ b/custom_components/mitsubishi/coordinator.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
+import requests
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from pymitsubishi import MitsubishiController, ParsedDeviceState
 
 from .const import (
@@ -94,6 +95,13 @@ class MitsubishiDataUpdateCoordinator(DataUpdateCoordinator[ParsedDeviceState]):
 
     async def _async_update_data(self) -> ParsedDeviceState:
         """Update data via library."""
+        try:
+            return await self._async_poll_device()
+        except requests.exceptions.RequestException as err:
+            raise UpdateFailed(f"Error communicating with the air conditioner: {err}") from err
+
+    async def _async_poll_device(self) -> ParsedDeviceState:
+        """Send any pending remote temperature, then fetch the device state."""
         _LOGGER.debug("[%s] Coordinator fetching device status", self.config_entry.title)
 
         # Only process remote temperature if experimental features are enabled

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import requests
 from homeassistant.const import CONF_HOST, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -379,3 +380,53 @@ async def test_send_remote_temperature_success(
         mock_executor.assert_called_once()
         # Remote mode should remain enabled on success
         assert coordinator._remote_temp_mode is True
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_connection_error_raises_update_failed(
+    hass, mock_mitsubishi_controller, mock_config_entry
+):
+    """A dropped connection is reported as UpdateFailed."""
+    coordinator = MitsubishiDataUpdateCoordinator(
+        hass, mock_mitsubishi_controller, mock_config_entry
+    )
+
+    error = requests.exceptions.ConnectionError(
+        "('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"
+    )
+
+    with patch.object(hass, "async_add_executor_job", AsyncMock(side_effect=error)):
+        with pytest.raises(UpdateFailed, match="Error communicating with the air conditioner"):
+            await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_connection_error_keeps_original_cause(
+    hass, mock_mitsubishi_controller, mock_config_entry
+):
+    """The originating requests error stays reachable as __cause__."""
+    coordinator = MitsubishiDataUpdateCoordinator(
+        hass, mock_mitsubishi_controller, mock_config_entry
+    )
+
+    error = requests.exceptions.ReadTimeout("timed out")
+
+    with patch.object(hass, "async_add_executor_job", AsyncMock(side_effect=error)):
+        with pytest.raises(UpdateFailed) as excinfo:
+            await coordinator._async_update_data()
+
+    assert excinfo.value.__cause__ is error
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_does_not_swallow_other_errors(
+    hass, mock_mitsubishi_controller, mock_config_entry
+):
+    """Errors that are not transport failures keep propagating unchanged."""
+    coordinator = MitsubishiDataUpdateCoordinator(
+        hass, mock_mitsubishi_controller, mock_config_entry
+    )
+
+    with patch.object(hass, "async_add_executor_job", AsyncMock(side_effect=ValueError("boom"))):
+        with pytest.raises(ValueError, match="boom"):
+            await coordinator._async_update_data()


### PR DESCRIPTION
## The problem

`_async_update_data` lets `requests` exceptions out of the coordinator. Home Assistant catches them in its legacy `RequestException` path and logs this on every poll for as long as the unit is unreachable:

```
ERROR (MainThread) [custom_components.mitsubishi.coordinator] Error requesting mitsubishi data:
('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

## The change

Transport errors are raised as `UpdateFailed`. Home Assistant logs one error and then repeats it at debug level. Entity availability is unchanged. Anything that is not a `requests` transport error propagates as before, so real faults are not swallowed.

The network calls moved into `_async_poll_device`, so the translation covers both the remote temperature write and the status fetch.

## Relationship to the library fix

The `RemoteDisconnected` failures above have their own root cause, already fixed in the library by pymitsubishi#26: the session mounted `Retry(total=4)`, and urllib3 leaves `POST` out of `allowed_methods` by default while all `/smart` traffic is `POST`, so a stale keep-alive connection was never retried.

This is not a substitute for that, and it does not depend on it either. Once that fix ships these errors become rare instead of routine, but a powered-down unit still produces them, and reporting those as `UpdateFailed` is the correct coordinator behavior on any library version.

It applies on the current pin and needs no release.

## Verification

Tests: 118 passed, 2 xfailed, coverage 87.40% against the 85% gate. Three new cases in `tests/test_coordinator.py` cover a dropped connection surfacing as `UpdateFailed`, the originating error staying reachable as `__cause__`, and a non-transport error still propagating unchanged.

I also ran this on a live instance with five adapters. All five entries load and poll normally, and the debug line that now lives inside `_async_poll_device` fires on every cycle, so the refactored path is the one being exercised:

```
DEBUG (MainThread) [custom_components.mitsubishi.coordinator] [Mitsubishi AC (...)] Coordinator fetching device status
```

I was not able to trigger a real transport failure on demand to watch the translation happen end to end, since all five adapters stayed reachable. The error branch is covered by tests rather than by observation, and I wanted to be upfront about that.
