### PR TITLE
Add a MELCloud connection switch

### DIFF
--- a/custom_components/mitsubishi/__init__.py
+++ b/custom_components/mitsubishi/__init__.py
@@ -33,6 +33,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.SELECT,
     Platform.NUMBER,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/mitsubishi/switch.py
+++ b/custom_components/mitsubishi/switch.py
@@ -1,0 +1,74 @@
+"""Switch platform for Mitsubishi Air Conditioner integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import MitsubishiDataUpdateCoordinator
+from .entity import MitsubishiEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Mitsubishi switches."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities([MitsubishiCloudConnectionSwitch(coordinator, config_entry)])
+
+
+class MitsubishiCloudConnectionSwitch(MitsubishiEntity, SwitchEntity):
+    """Controls whether the adapter connects to the MELCloud servers.
+
+    Turning this off keeps the air conditioner fully usable over the local
+    network. It only stops the adapter from talking to the manufacturer's
+    cloud service.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_icon = "mdi:cloud-outline"
+
+    def __init__(
+        self,
+        coordinator: MitsubishiDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, config_entry, "cloud_connection")
+        self._attr_name = "MELCloud connection"
+
+    @property
+    def available(self) -> bool:
+        """Return if the adapter reported its cloud connection setting."""
+        return super().available and self.coordinator.data.cloud_connect is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the adapter connects to the MELCloud servers."""
+        return self.coordinator.data.cloud_connect
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Let the adapter connect to the MELCloud servers."""
+        await self._execute_command_with_refresh(
+            "enable MELCloud connection",
+            self.coordinator.controller.set_cloud_connect,
+            True,
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Stop the adapter from connecting to the MELCloud servers."""
+        await self._execute_command_with_refresh(
+            "disable MELCloud connection",
+            self.coordinator.controller.set_cloud_connect,
+            False,
+        )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,104 @@
+"""Tests for the Mitsubishi cloud connection switch."""
+
+import dataclasses
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.components.switch import SwitchDeviceClass
+from homeassistant.const import EntityCategory
+from pymitsubishi import ParsedDeviceState
+
+from custom_components.mitsubishi.const import DOMAIN
+from custom_components.mitsubishi.switch import (
+    MitsubishiCloudConnectionSwitch,
+    async_setup_entry,
+)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry(hass, mock_coordinator, mock_config_entry):
+    """Test the setup of the Mitsubishi switch entities."""
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_coordinator}
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], MitsubishiCloudConnectionSwitch)
+
+
+@pytest.mark.asyncio
+async def test_switch_init(hass, mock_coordinator, mock_config_entry):
+    """Test cloud connection switch initialization."""
+    switch = MitsubishiCloudConnectionSwitch(mock_coordinator, mock_config_entry)
+
+    assert switch._attr_name == "MELCloud connection"
+    assert switch._attr_icon == "mdi:cloud-outline"
+    assert switch._attr_device_class == SwitchDeviceClass.SWITCH
+    assert switch._attr_entity_category == EntityCategory.CONFIG
+    assert switch.unique_id.endswith("_cloud_connection")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reported", [True, False])
+async def test_is_on_follows_the_adapter(hass, mock_coordinator, mock_config_entry, reported):
+    """The switch reports whatever setting the adapter last returned."""
+    mock_coordinator.data.cloud_connect = reported
+    switch = MitsubishiCloudConnectionSwitch(mock_coordinator, mock_config_entry)
+
+    assert switch.is_on is reported
+
+
+@pytest.mark.asyncio
+async def test_unavailable_until_the_adapter_reports(hass, mock_coordinator, mock_config_entry):
+    """Before the first status fetch the setting is unknown."""
+    mock_coordinator.data.cloud_connect = None
+    switch = MitsubishiCloudConnectionSwitch(mock_coordinator, mock_config_entry)
+
+    assert switch.available is False
+
+
+@pytest.mark.asyncio
+async def test_available_once_reported(hass, mock_coordinator, mock_config_entry):
+    """Test availability once the adapter has reported the setting."""
+    mock_coordinator.data.cloud_connect = True
+    switch = MitsubishiCloudConnectionSwitch(mock_coordinator, mock_config_entry)
+
+    assert switch.available is True
+
+
+@pytest.mark.asyncio
+async def test_turn_on_enables_the_connection(hass, mock_coordinator, mock_config_entry):
+    """Test turning the cloud connection on."""
+    switch = MitsubishiCloudConnectionSwitch(mock_coordinator, mock_config_entry)
+
+    with patch.object(switch, "_execute_command_with_refresh", AsyncMock()) as execute:
+        await switch.async_turn_on()
+
+    execute.assert_called_once_with(
+        "enable MELCloud connection",
+        mock_coordinator.controller.set_cloud_connect,
+        True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_off_disables_the_connection(hass, mock_coordinator, mock_config_entry):
+    """Test turning the cloud connection off."""
+    switch = MitsubishiCloudConnectionSwitch(mock_coordinator, mock_config_entry)
+
+    with patch.object(switch, "_execute_command_with_refresh", AsyncMock()) as execute:
+        await switch.async_turn_off()
+
+    execute.assert_called_once_with(
+        "disable MELCloud connection",
+        mock_coordinator.controller.set_cloud_connect,
+        False,
+    )
+
+
+def test_library_exposes_the_cloud_setting():
+    """The switch reads cloud_connect off the parsed state, so the pinned library must carry it."""
+    assert "cloud_connect" in {f.name for f in dataclasses.fields(ParsedDeviceState)}


### PR DESCRIPTION
## What this adds

The adapter treats the `CONNECT` element of a `/smart` request as a stored setting rather than a per-request flag. A status poll that sends `CONNECT ON` therefore re-enables the connection to the MELCloud servers, so a local-only installation could never stay disconnected. Turning it off in the adapter's own UI held only until the next poll.

pymitsubishi#28, released in v0.6.0, fixed the library half: `send_status_request()` omits the element by default, `set_cloud_connect()` changes it deliberately, and `ParsedDeviceState` reports `cloud_connect`.

This adds the Home Assistant half: a `MELCloud connection` switch, in the config entity category, that shows the setting and lets it be turned off and left off. Local control over `/smart` keeps working while the cloud connection is off.

## Changes

- `switch.py` adds `MitsubishiCloudConnectionSwitch`. It reads `coordinator.data.cloud_connect` and calls `controller.set_cloud_connect()`, and stays unavailable until the adapter has reported the setting.
- `__init__.py` registers `Platform.SWITCH`.

No manifest change is needed, since `main` already pins `pymitsubishi==0.6.0`.

## Tests

`tests/test_switch.py` covers setup, the entity attributes, the reported state in both directions, availability before the first report, and both directions of the toggle. It also asserts that `ParsedDeviceState` carries `cloud_connect`, so a pin that predates the library support fails the suite rather than failing at runtime.

Suite: 124 passed, 2 xfailed, coverage 87.78% against the 85% gate. `switch.py` is at 100%. `ruff check` and `ruff format --check` are clean.

## Verified on hardware

Run against five adapters (four MAC-577IF-E and one MAC-567IFB-E). All five switches populate from the adapter's reported setting, and toggling one off and back on through the `switch.turn_off` and `switch.turn_on` actions changed the adapter's "Server operation" state and survived subsequent polls.
