### PR TITLE
Add DHCP flow support

### DIFF
--- a/custom_components/mitsubishi/config_flow.py
+++ b/custom_components/mitsubishi/config_flow.py
@@ -12,6 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from pymitsubishi import MitsubishiAPI, MitsubishiController
 
 from .const import (
@@ -202,6 +204,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data=self._connection_data,
             options=options,
         )
+
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> Any:
+        """Handle dhcp discovery to update existing entries.
+
+        This flow is triggered only by DHCP discovery of known devices.
+        """
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+
+        return self.async_abort(reason="unknown")
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/mitsubishi/config_flow.py
+++ b/custom_components/mitsubishi/config_flow.py
@@ -210,9 +210,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             options=options,
         )
 
-    async def async_step_dhcp(
-        self, discovery_info: DhcpServiceInfo
-    ) -> Any:
+    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> Any:
         """Handle dhcp discovery to update existing entries.
 
         This flow is triggered only by DHCP discovery of known devices.

--- a/custom_components/mitsubishi/config_flow.py
+++ b/custom_components/mitsubishi/config_flow.py
@@ -13,8 +13,13 @@ from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from pymitsubishi import MitsubishiAPI, MitsubishiController
+
+try:
+    from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+except ImportError:
+    from homeassistant.components.dhcp import DhcpServiceInfo  # deprecated in Home Assistant 2026.2
+
 
 from .const import (
     CONF_ADMIN_PASSWORD,

--- a/custom_components/mitsubishi/entity.py
+++ b/custom_components/mitsubishi/entity.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo, format_mac
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_OPTIMISTIC_UPDATES, DEFAULT_OPTIMISTIC_UPDATES, DOMAIN
@@ -67,6 +67,7 @@ class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
             else f"Mitsubishi AC ({config_entry.data['host']})",
             hw_version=device_mac,
             serial_number=device_serial,
+            connections={(CONNECTION_NETWORK_MAC, format_mac(device_mac))} if device_serial else set(),
             configuration_url=f"http://{config_entry.data['host']}",
         )
 

--- a/custom_components/mitsubishi/entity.py
+++ b/custom_components/mitsubishi/entity.py
@@ -67,7 +67,9 @@ class MitsubishiEntity(CoordinatorEntity[MitsubishiDataUpdateCoordinator]):
             else f"Mitsubishi AC ({config_entry.data['host']})",
             hw_version=device_mac,
             serial_number=device_serial,
-            connections={(CONNECTION_NETWORK_MAC, format_mac(device_mac))} if device_serial else set(),
+            connections={(CONNECTION_NETWORK_MAC, format_mac(device_mac))}
+            if device_serial
+            else set(),
             configuration_url=f"http://{config_entry.data['host']}",
         )
 

--- a/custom_components/mitsubishi/manifest.json
+++ b/custom_components/mitsubishi/manifest.json
@@ -5,6 +5,11 @@
     "@ashleigh-hopkins"
   ],
   "config_flow": true,
+  "dhcp": [
+    {
+      "registered_devices": true
+    }
+  ],
   "documentation": "https://github.com/pymitsubishi/homeassistant-mitsubishi",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -329,7 +329,7 @@ class TestConfigFlow:
                 CONF_ADMIN_PASSWORD: "password",
                 CONF_SCAN_INTERVAL: 30,
             },
-            entry_id="test_entry_id",
+            entry_id="00:11:22:33:44:55",
         )
         mock_entry.add_to_hass(hass)
         assert mock_entry.data[CONF_HOST] == "192.168.1.100"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -319,22 +319,25 @@ class TestConfigFlow:
     async def test_reconfigure_dhcp(self, hass: HomeAssistant, mock_api, mock_controller) -> None:
         """Test reconfiguring existing entry."""
 
-        mock_entry = MockConfigEntry(
-            domain=DOMAIN,
-            title="Test Device",
-            data={
-                CONF_HOST: "192.168.1.100",
-                CONF_ENCRYPTION_KEY: "test_key",
-                CONF_ADMIN_USERNAME: "admin",
-                CONF_ADMIN_PASSWORD: "password",
-                CONF_SCAN_INTERVAL: 30,
-            },
-            entry_id="00:11:22:33:44:55",
-        )
-        mock_entry.add_to_hass(hass)
-        assert mock_entry.data[CONF_HOST] == "192.168.1.100"
-
         result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        with patch("custom_components.mitsubishi.config_flow.MitsubishiAPI") as mock_api_class:
+            mock_api_class.return_value = mock_api
+
+            with patch(
+                "custom_components.mitsubishi.config_flow.MitsubishiController"
+            ) as mock_controller_class:
+                mock_controller_class.return_value = mock_controller
+
+                result2 = await hass.config_entries.flow.async_configure(
+                    result["flow_id"],
+                    {"host": "192.168.1.100"},
+                )
+                assert result2["type"] == FlowResultType.CREATE_ENTRY
+
+        result2 = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
             data=DhcpServiceInfo(
@@ -343,9 +346,12 @@ class TestConfigFlow:
                 macaddress="001122334455",
             ),
         )
-        assert result["type"] is FlowResultType.ABORT
-        assert result["reason"] == "already_configured"
-        assert mock_entry.data[CONF_HOST] == "192.168.1.101"
+        assert result2["type"] is FlowResultType.ABORT
+        assert result2["reason"] == "already_configured"
+
+        entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "00:11:22:33:44:55")
+        assert entry
+        assert entry.data[CONF_HOST] == "192.168.1.101"
 
 
 class TestOptionsFlow:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -26,6 +26,11 @@ from custom_components.mitsubishi.const import (
 
 from . import TEST_SYSTEM_DATA, USER_INPUT
 
+try:
+    from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+except ImportError:
+    from homeassistant.components.dhcp import DhcpServiceInfo  # deprecated in Home Assistant 2026.2
+
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test that form shows up."""
@@ -309,6 +314,36 @@ class TestConfigFlow:
 
             # Verify API was closed even when exception occurs
             mock_api.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_dhcp(self, hass: HomeAssistant, mock_api, mock_controller) -> None:
+        """Test reconfiguring existing entry."""
+
+        mock_entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Device",
+            data={
+                CONF_HOST: "192.168.1.100",
+                CONF_ENCRYPTION_KEY: "test_key",
+                CONF_ADMIN_USERNAME: "admin",
+                CONF_ADMIN_PASSWORD: "password",
+                CONF_SCAN_INTERVAL: 30,
+            },
+            entry_id="test_entry_id",
+        )
+        mock_entry.add_to_hass(hass)
+        assert mock_entry.data[CONF_HOST] == "192.168.1.100"
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DhcpServiceInfo(
+                hostname="mitsubishi",
+                ip="192.168.1.101",
+                macaddress="001122334455",
+            )
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+        assert mock_entry.data[CONF_HOST] == "192.168.1.101"
 
 
 class TestOptionsFlow:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -335,11 +335,13 @@ class TestConfigFlow:
         assert mock_entry.data[CONF_HOST] == "192.168.1.100"
 
         result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=DhcpServiceInfo(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=DhcpServiceInfo(
                 hostname="mitsubishi",
                 ip="192.168.1.101",
                 macaddress="001122334455",
-            )
+            ),
         )
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "already_configured"

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from custom_components.mitsubishi.const import DOMAIN
 from custom_components.mitsubishi.entity import MitsubishiEntity
@@ -35,6 +36,7 @@ async def test_mitsubishi_entity_initialization(hass):
     assert entity.device_info["name"] == "Mitsubishi AC 33:44:55"
     assert entity.device_info["hw_version"] == "00:11:22:33:44:55"
     assert entity.device_info["serial_number"] == "TEST123456"
+    assert entity.device_info["connections"] == {CONNECTION_NETWORK_MAC: "00:11:22:33:44:55"}
 
     # Check unique ID
     assert entity.unique_id == "00:11:22:33:44:55_test_key"
@@ -92,6 +94,7 @@ async def test_mitsubishi_entity_initialization_with_none_data(hass):
     assert entity.device_info["name"] == "Mitsubishi AC 68.1.100"  # Last 8 chars of IP
     assert entity.device_info["hw_version"] == "192.168.1.100"
     assert entity.device_info["serial_number"] is None
+    assert entity.device_info["connections"] == set()  # No network MAC available
 
     # Check unique ID
     assert entity.unique_id == "192.168.1.100_test_key"

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -36,7 +36,7 @@ async def test_mitsubishi_entity_initialization(hass):
     assert entity.device_info["name"] == "Mitsubishi AC 33:44:55"
     assert entity.device_info["hw_version"] == "00:11:22:33:44:55"
     assert entity.device_info["serial_number"] == "TEST123456"
-    assert entity.device_info["connections"] == {CONNECTION_NETWORK_MAC: "00:11:22:33:44:55"}
+    assert entity.device_info["connections"] == {(CONNECTION_NETWORK_MAC, "00:11:22:33:44:55")}
 
     # Check unique ID
     assert entity.unique_id == "00:11:22:33:44:55_test_key"


### PR DESCRIPTION
Currently when Mitsubishi devices won't have a static ip-adress in your network the connection can be lost when IP changes. When setting the mac address as device info-connections, home assistant build-in dhcp support can update the ip-adress of the device when it changes. Patch have been running locally without any issues (HA 2026.8+).
In addition to this, a new device is added in the "Living room" when the IP changes, this is not included in this PR and can be added in a seperate one if wished.

**DHCP Discovery and Config Flow Enhancements:**

* Added a new `async_step_dhcp` method to the `config_flow.py` to handle DHCP discovery and update existing entries with new IP addresses based on MAC address matching.
* Updated `manifest.json` to declare DHCP support for registered devices.

**Entity and Device Info Improvements:**

* Updated `entity.py` to set the `connections` field in `DeviceInfo` with the formatted MAC address when available.

**Testing Enhancements:**

* Added tests to verify DHCP-based reconfiguration, ensuring that IP addresses are updated for existing entries.